### PR TITLE
Symbol field in deref node

### DIFF
--- a/src/entities/ast/logocommands.py
+++ b/src/entities/ast/logocommands.py
@@ -99,6 +99,7 @@ class Make(Node):
         if arg_node.type == "Deref":
             arg_name = arg_node.leaf
             arg_symbol = self._symbol_tables.variables.lookup(arg_name)
+            arg_node.set_symbol(arg_symbol)
 
         arg_logotype = arg_node.get_type()
 

--- a/src/entities/ast/variables.py
+++ b/src/entities/ast/variables.py
@@ -32,32 +32,31 @@ class Deref(Node):
         self._symbol: Variable = None
 
     def set_symbol(self, symbol: Variable):
-        if symbol != self._get_symbol():
+        if symbol != self.get_symbol():
             raise Exception(
                 (f"Bug: variable symbol param {symbol} and the symbol defined"
-                f"in symbol_table {self._get_symbol} do not match"))
+                f"in symbol_table {self.get_symbol()} do not match"))
         self._symbol = symbol
 
     def get_logotype(self) -> LogoType:
-        symbol = self._get_symbol()
+        symbol = self.get_symbol()
         if symbol:
             return symbol.typeclass.logotype
         return None
 
     def get_typeclass(self) -> Type:
-        symbol = self._get_symbol()
+        symbol = self.get_symbol()
         if symbol:
             return symbol.typeclass
         return None
 
-    def _get_symbol(self) -> Variable:
-        symbol = self._symbol_tables.variables.lookup(self.leaf)
-        if symbol:
-            return symbol
-        return None
+    def get_symbol(self) -> Variable:
+        if self._symbol:
+            return self._symbol
+        return self._symbol_tables.variables.lookup(self.leaf)
 
     def check_types(self):
-        symbol = self._get_symbol()
+        symbol = self.get_symbol()
         if not symbol:
             self._logger.error_handler.add_error(2007, var=self.leaf)
 

--- a/src/entities/ast/variables.py
+++ b/src/entities/ast/variables.py
@@ -41,6 +41,14 @@ class Bool(Node):
 class Deref(Node):
     def __init__(self, leaf, **dependencies):
         super().__init__("Deref", children=None, leaf=leaf, **dependencies)
+        self._symbol: Variable = None
+
+    def set_symbol(self, symbol: Variable):
+        if symbol != self._get_symbol():
+            raise Exception(
+                (f"Bug: variable symbol param {symbol} and the symbol defined"
+                f"in symbol_table {self._get_symbol} do not match"))
+        self._symbol = symbol
 
     def get_type(self) -> LogoType:
         symbol = self._get_symbol()

--- a/src/utils/console_io.py
+++ b/src/utils/console_io.py
@@ -17,9 +17,9 @@ class ConsoleIO:
     @staticmethod
     def print_ast(ast, indent=""):
         """Prints ast as formatted string"""
-        print(indent + "Type: " + str(ast.type))
+        print(indent + "Type: " + str(ast.node_type))
         print(indent + "Leaf: " + str(ast.leaf))
-        print(indent + "Logotype: " + str(ast.get_type()))
+        print(indent + "Logotype: " + str(ast.get_logotype()))
         print(indent + "Children: ")
         for child in ast.children:
             default_console_io.print_ast(child, indent + "\t")


### PR DESCRIPTION
Lisätty self._symbol Deref nodeen, josta saadaan dereffin tyyppi symbolin kautta koodigeneroinnissa. self._symbol arvo asetetaan logocommands.py rivillä 100