### PR TITLE
Show Finnish translation fix

### DIFF
--- a/src/lexer/lexer.py
+++ b/src/lexer/lexer.py
@@ -47,7 +47,7 @@ class Lexer:
         "for": TokenType.FOR,
         "luvuille": TokenType.FOR,
         "show": TokenType.SHOW,
-        "näytä": TokenType.SHOW,
+        "tulosta": TokenType.SHOW,
         "true": TokenType.TRUE,
         "joo": TokenType.TRUE,
         "false": TokenType.FALSE,

--- a/src/tests/lexer_test.py
+++ b/src/tests/lexer_test.py
@@ -185,7 +185,7 @@ class TestLexer(unittest.TestCase):
         tok = self.lexer.t_IDENT(self.token_mock)
         self.assertEqual(tok.type, "SHOW")
 
-        self.token_mock.value = "näytä"
+        self.token_mock.value = "tulosta"
         tok = self.lexer.t_IDENT(self.token_mock)
         self.assertEqual(tok.type, "SHOW")
 


### PR DESCRIPTION
JSLogon mukaan komennon "show" suomenkielinen versio on "tulosta" eikä "näytä". Korjattu tässä branchissa.