### PR TITLE
Lowercase converter

### DIFF
--- a/logo/case_insensitive.logo
+++ b/logo/case_insensitive.logo
@@ -1,0 +1,12 @@
+To Sum :First :Second
+	Make "Result :first + :second
+	Output :result
+End
+
+TO MULTIPLY :FIRST :SECOND
+	MAKE "RESULT :first * :second
+	OUTPUT :result
+END
+
+make "x (SUM 2 2)
+make "y (multiply 2 2)

--- a/src/entities/ast/functions.py
+++ b/src/entities/ast/functions.py
@@ -4,6 +4,7 @@ from entities.logotypes import LogoType
 from entities.symbol import Function, Variable
 from entities.type import Type
 from entities.ast.variables import Deref
+from utils.lowercase_converter import convert_to_lowercase as to_lowercase
 
 
 class Output(Node):
@@ -178,4 +179,4 @@ class ProcArg(Node):
 
     def get_param_data(self):
         """Return function parameter's type and name in tuple for ProgArgs' generate_code"""
-        return (self.get_logotype(), self.leaf.lower())
+        return (self.get_logotype(), to_lowercase(self.leaf))

--- a/src/entities/ast/functions.py
+++ b/src/entities/ast/functions.py
@@ -107,7 +107,7 @@ class ProcCall(Node):
         for child in self.children:
             temp_vars.append(child.generate_code())
         if self.get_logotype() == LogoType.VOID:
-            self._code_generator.function_call(self.leaf, temp_vars)
+            self._code_generator.function_call(to_lowercase(self.leaf), temp_vars)
             return None
         return self._code_generator.returning_function_call(to_lowercase(self.leaf), temp_vars)
 

--- a/src/entities/ast/functions.py
+++ b/src/entities/ast/functions.py
@@ -91,7 +91,7 @@ class ProcCall(Node):
         if self.get_logotype() == LogoType.VOID:
             self._code_generator.function_call(self.leaf, temp_vars)
             return None
-        return self._code_generator.returning_function_call(self.leaf, temp_vars)
+        return self._code_generator.returning_function_call(to_lowercase(self.leaf), temp_vars)
 
 
 class ProcDecl(Node):
@@ -134,7 +134,7 @@ class ProcDecl(Node):
 
     def generate_code(self):
         self._code_generator.start_function_declaration(
-            logo_func_name=self.leaf, logo_func_type=self.get_logotype()
+            logo_func_name=to_lowercase(self.leaf), logo_func_type=self.get_logotype()
         )
         for child in self.children:
             child.generate_code()

--- a/src/entities/ast/logocommands.py
+++ b/src/entities/ast/logocommands.py
@@ -3,6 +3,7 @@ from entities.logotypes import LogoType
 from entities.symbol import Variable
 from entities.type import Type
 from lexer.token_types import TokenType
+from utils.lowercase_converter import convert_to_lowercase as to_lowercase
 
 
 class Make(Node):
@@ -155,9 +156,9 @@ class Make(Node):
         value_var_name = self.children[0].generate_code()
 
         if self._new_variable:
-            self._code_generator.create_new_variable(self.leaf.leaf.lower(), value_var_name)
+            self._code_generator.create_new_variable(to_lowercase(self.leaf.leaf), value_var_name)
         else:
-            self._code_generator.assign_value(self.leaf.leaf.lower(), value_var_name)
+            self._code_generator.assign_value(to_lowercase(self.leaf.leaf), value_var_name)
 
 
 class Show(Node):

--- a/src/entities/ast/variables.py
+++ b/src/entities/ast/variables.py
@@ -2,6 +2,7 @@ from entities.ast.node import Node
 from entities.logotypes import LogoType
 from entities.symbol import Variable
 from entities.type import Type
+from utils.lowercase_converter import convert_to_lowercase as to_lowercase
 
 
 class Float(Node):
@@ -69,7 +70,7 @@ class Deref(Node):
             self._logger.error_handler.add_error(2007, self.position.get_lexspan(), var=self.leaf)
 
     def generate_code(self):
-        return self._code_generator.variable_name(self.leaf.lower())
+        return self._code_generator.variable_name(to_lowercase(self.leaf))
 
 
 class StringLiteral(Node):

--- a/src/entities/symbol_table.py
+++ b/src/entities/symbol_table.py
@@ -1,5 +1,6 @@
 """Symbol table module"""
 from collections import deque
+from utils.lowercase_converter import convert_to_lowercase as to_lowercase
 
 
 class SymbolTable:
@@ -18,15 +19,13 @@ class SymbolTable:
 
     def insert(self, key, value):
         """Inserts a new entry to the symbol table"""
-        if isinstance(key, str):
-            key = key.lower()
+        key = to_lowercase(key)
         self._stack[0][key] = value
 
     def lookup(self, key):
         """Searches for a symbol and returns its value.
         Global scope can't be reached in function scope"""
-        if isinstance(key, str):
-            key = key.lower()
+        key = to_lowercase(key)
         if self._in_function:
             for i in range(len(self._stack) - 1):
                 if key in self._stack[i]:

--- a/src/lexer/lexer.py
+++ b/src/lexer/lexer.py
@@ -6,6 +6,7 @@ Lexer module used by PLY's lexer-generator.
 from ply.lex import lex, TOKEN
 from lexer.token_types import TokenType
 from utils.logger import default_logger
+from utils.lowercase_converter import convert_to_lowercase as to_lowercase
 
 
 class Lexer:
@@ -103,7 +104,7 @@ class Lexer:
     @TOKEN(FUNCTION_NAME)
     def t_IDENT(self, token):
         """Used for tokenizing all identifiers, keywords."""
-        word = token.value.lower()
+        word = to_lowercase(token.value)
         token.value = word
         token.type = self.reserved_words.get(word, TokenType.IDENT).value
         return token

--- a/src/tests/code_generation_test.py
+++ b/src/tests/code_generation_test.py
@@ -12,9 +12,9 @@ from entities.ast.operations import BinOp
 from entities.ast.operations import RelOp
 from entities.ast.operations import UnaryOp
 from entities.ast.conditionals import If
-from entities.ast.functions import ProcCall
+from entities.ast.functions import ProcCall, ProcDecl, ProcArgs, ProcArg
 from entities.logotypes import LogoType
-from entities.symbol import Function
+from entities.symbol import Function, Variable
 from entities.type import Type
 from lexer.token_types import TokenType
 from entities.symbol_table import default_variable_table
@@ -139,3 +139,30 @@ class CodegenTest(unittest.TestCase):
         node_function.generate_code()
         node_list = default_code_generator.get_generated_code()
         self.assertEqual("var temp1 = logo.func2();", node_list[0])
+
+    def test_make_leaf_is_case_insensitive(self):
+        node_float1 = Float(leaf=1.0)
+        node_float2 = Float(leaf=2.0)
+        node_name1 = StringLiteral(leaf="Test")
+        node_name2 = StringLiteral(leaf="tEST")
+        node_make1 = Make(children=[node_float1], leaf=node_name1)
+        node_make2 = Make(children=[node_float2], leaf=node_name2)
+        nodes = StatementList(children=[node_make1, node_make2])
+        nodes.check_types()
+        nodes.generate_code()
+        node_list = default_code_generator.get_generated_code()
+        self.assertEqual("var var2 = temp1;", node_list[1])
+        self.assertEqual("var2 = temp3;", node_list[3])
+
+    def test_variables_are_case_insensitive(self):
+        node_float = Float(leaf=1.0)
+        node_name1 = StringLiteral(leaf="Test1")
+        node_name2 = StringLiteral(leaf="Test2")
+        node_make1 = Make(children=[node_float], leaf=node_name1)
+        node_make2 = Make(children=[Deref(leaf="tEST1")], leaf=node_name2)
+        nodes = StatementList(children=[node_make1, node_make2])
+        nodes.check_types()
+        nodes.generate_code()
+        node_list = default_code_generator.get_generated_code()
+        self.assertEqual("var var2 = temp1;", node_list[1])
+        self.assertEqual("var var3 = var2;", node_list[2])

--- a/src/tests/functions_test.py
+++ b/src/tests/functions_test.py
@@ -84,3 +84,15 @@ class TestFunctions(unittest.TestCase):
         ast = self.parser.parse(test_code)
         ast.check_types()
         self.assertEqual(True, self.error_handler.check_id_is_in_errors(2022))
+
+    def test_function_calls_are_case_insensitive(self):
+        test_code = """TO Test output 1 END make "x (tEST)"""
+        ast = self.parser.parse(test_code)
+        ast.check_types()
+        self.assertEqual(len(self.error_handler.error_ids), 0)
+
+    def test_function_params_are_case_insensitive(self):
+        test_code = """TO test.func :test.param make "x :tEST.pARAM+0 END"""
+        ast = self.parser.parse(test_code)
+        ast.check_types()
+        self.assertEqual(len(self.error_handler.error_ids), 0)

--- a/src/tests/symbol_table_test.py
+++ b/src/tests/symbol_table_test.py
@@ -128,3 +128,8 @@ class TestSymbolTable(unittest.TestCase):
         self.st.initialize_scope(in_function="function x's symbol")
         result = self.st.get_in_scope_function_symbol()
         self.assertEqual(result, "function x's symbol")
+
+    def test_symbols_in_the_table_are_case_insensitive(self):
+        self.st.insert("x", self.value1)
+        re = self.st.lookup("X")
+        self.assertEqual(re, self.value1)

--- a/src/utils/lowercase_converter.py
+++ b/src/utils/lowercase_converter.py
@@ -1,6 +1,6 @@
 """A module housing the method to abstractly convert strings to lowercase"""
 
-def convert_to_lowercase(string: str):
+def convert_to_lowercase(string):
     """Convert a string to lowercase. If used for non-strings, will return an unmodified object"""
 
     if isinstance(string, str):

--- a/src/utils/lowercase_converter.py
+++ b/src/utils/lowercase_converter.py
@@ -1,6 +1,6 @@
 """A module housing the method to abstractly convert strings to lowercase"""
 
-def convert_to_lowercase(string: str) -> str:
+def convert_to_lowercase(string: str):
     """Convert a string to lowercase. If used for non-strings, will return an unmodified object"""
 
     if isinstance(string, str):

--- a/src/utils/lowercase_converter.py
+++ b/src/utils/lowercase_converter.py
@@ -1,0 +1,8 @@
+"""A module housing the method to abstractly convert strings to lowercase"""
+
+def convert_to_lowercase(string: str) -> str:
+    """Convert a string to lowercase. If used for non-strings, will return an unmodified object"""
+
+    if isinstance(string, str):
+        return string.lower()
+    return string


### PR DESCRIPTION
Uusi moduuli metodille `convert_to_lowercase()`. `.lower()` kohdat muutettu muotoon `to_lowercase()`. Lisäyksiä kohtiin, joista `.lower()` aiemmin puuttui. Muutama testi testaamaan kirjainlajiriippumattomuutta. Uusi .logo-tiedosto demonstroimaan kirjainlajiriippumattomuutta.